### PR TITLE
Add dry-run indicator to trade bot messages

### DIFF
--- a/src/services/trade_service.py
+++ b/src/services/trade_service.py
@@ -305,6 +305,7 @@ async def execute_trade(*, csv_path: str, market_id: str, investment_usd: float,
                 "action": "开仓",
                 "strategy": int(strategy),
                 "market_title": market_title,
+                "simulate": bool(dry_run),
                 "pm_side": "买入",
                 "pm_token": "YES" if strategy == 1 else "NO",
                 "pm_price": float(limit_price),          # 注意：这里用 limit_price 近似成交均价

--- a/src/telegram/formatter_v2.py
+++ b/src/telegram/formatter_v2.py
@@ -61,6 +61,7 @@ def format_message(msg: TelegramMessage) -> str:
             "💰 交易已执行\n"
             f"类型: {d.action}\n"
             f"策略: {d.strategy}\n"
+            f"模拟: {str(bool(d.simulate)).lower()}\n"
             f"市场: {d.market_title}\n"
             f"PM: {d.pm_side} {d.pm_token} @ ${d.pm_price:.4f} (${_fmt_money(d.pm_amount_usd, 0)})\n"
             f"Deribit: {d.deribit_action} {d.deribit_k1}-{d.deribit_k2} ({d.deribit_contracts:.6f}份)\n"

--- a/src/telegram/models.py
+++ b/src/telegram/models.py
@@ -23,6 +23,7 @@ class TradeData(BaseModel):
     action: Literal["开仓", "平仓"]
     strategy: Literal[1, 2]
     market_title: str
+    simulate: bool = False
     pm_side: Literal["买入", "卖出"]
     pm_token: Literal["YES", "NO"]
     pm_price: float


### PR DESCRIPTION
## Summary
- include dry-run mode flag from configuration in trade notifications
- render the simulation flag in trade bot messages alongside existing trade details

## Testing
- python -m compileall src/main.py src/telegram/formatter_v2.py src/telegram/models.py src/services/trade_service.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b080a37c48321aeef0c9cd907db8d)