### PR TITLE
Remove duplicate trade notification from main loop

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -437,33 +437,6 @@ async def loop_event(
             csv_row = result.to_csv_row(timestamp, deribit_ctx, poly_ctx, strategy)
             save_result_csv(csv_row, csv_path=output_csv)
 
-            tg_worker.publish(
-                {
-                    "type": "trade",
-                    "data": {
-                        "action": "开仓",
-                        "strategy": int(strategy),
-                        "market_title": _fmt_market_title(deribit_ctx.asset, deribit_ctx.K_poly),
-                        "simulate": dry_trade_mode,
-                        "pm_side": "买入",
-                        "pm_token": "YES" if strategy == 1 else "NO",
-                        "pm_price": pm_price,
-                        "pm_amount_usd": inv_base_usd,
-                        "deribit_action": "卖出牛差" if strategy == 1 else "买入牛差",
-                        "deribit_k1": float(deribit_ctx.k1_strike),
-                        "deribit_k2": float(deribit_ctx.k2_strike),
-                        "deribit_contracts": float(result.contracts),
-                        "fees_total": float(result.total_costs_yes if strategy == 1 else result.total_costs_no),
-                        "slippage_usd": 0.0,
-                        "open_cost": float(result.open_cost_yes if strategy == 1 else result.open_cost_no),
-                        "margin_usd": float(result.im_usd),
-                        "net_ev": net_ev,
-                        "note": "",
-                        "timestamp": _iso_utc_now(),
-                    },
-                }
-            )
-
             trade_id = (
                 f"auto-{deribit_ctx.asset}_{int(round(deribit_ctx.K_poly))}-s{int(strategy)}-"
                 f"{int(datetime.now(timezone.utc).timestamp())}"


### PR DESCRIPTION
## Summary
- remove the trade-type Telegram publish from the monitoring loop to avoid duplicate trade execution notifications

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b69e45cfc8321be491539f957eee7)