### PR TITLE
Expose strike quotes and IV on EV endpoint

### DIFF
--- a/src/services/api_models.py
+++ b/src/services/api_models.py
@@ -135,6 +135,14 @@ class EVMetrics(BaseModel):
     ev_percentage: float
 
 
+class StrikeQuote(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    bid: Optional[float] = None
+    ask: Optional[float] = None
+    iv: Optional[float] = None
+
+
 class EVMarketData(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -142,6 +150,8 @@ class EVMarketData(BaseModel):
     pm_no_price: float
     dr_probability: float
     divergence: float
+    k1: StrikeQuote
+    k2: StrikeQuote
 
 
 class Opportunity(BaseModel):

--- a/src/services/data_adapter.py
+++ b/src/services/data_adapter.py
@@ -20,6 +20,7 @@ from .api_models import (
     OptionsData,
     PMOrderBook,
     PMOrderBookSide,
+    StrikeQuote,
     PMSnapshotResponse,
     SpotPrice,
     VerticalSpread,
@@ -353,6 +354,14 @@ def load_ev_snapshot(csv_path: str) -> EVResponse:
         dr_prob = float(_safe_float(r.get("deribit_prob")) or 0.0)
         divergence = float(pm_yes - dr_prob)
 
+        k1_bid = _safe_float(r.get("k1_bid_btc"))
+        k1_ask = _safe_float(r.get("k1_ask_btc"))
+        k2_bid = _safe_float(r.get("k2_bid_btc"))
+        k2_ask = _safe_float(r.get("k2_ask_btc"))
+
+        k1_iv = _safe_float(r.get("k1_iv"))
+        k2_iv = _safe_float(r.get("k2_iv"))
+
         # Filter later; rank later
         opps.append(
             Opportunity(
@@ -368,6 +377,8 @@ def load_ev_snapshot(csv_path: str) -> EVResponse:
                     pm_no_price=pm_no,
                     dr_probability=dr_prob,
                     divergence=divergence,
+                    k1=StrikeQuote(bid=k1_bid, ask=k1_ask, iv=k1_iv),
+                    k2=StrikeQuote(bid=k2_bid, ask=k2_ask, iv=k2_iv),
                 ),
             )
         )

--- a/src/strategy/investment_runner.py
+++ b/src/strategy/investment_runner.py
@@ -153,6 +153,8 @@ class InvestmentResult:
             "k1_ask_btc": deribit_ctx.k1_ask_btc,
             "k2_bid_btc": deribit_ctx.k2_bid_btc,
             "k2_ask_btc": deribit_ctx.k2_ask_btc,
+            "k1_iv": deribit_ctx.k1_iv,
+            "k2_iv": deribit_ctx.k2_iv,
             # === 策略1完整数据 ===
             "net_ev_strategy1": self.net_ev_strategy1,
             "gross_ev_strategy1": self.gross_ev_strategy1,

--- a/src/utils/save_result.py
+++ b/src/utils/save_result.py
@@ -41,6 +41,8 @@ class ResultsCsvHeader:
     k1_ask_btc: str = "k1_ask_btc"
     k2_bid_btc: str = "k2_bid_btc"
     k2_ask_btc: str = "k2_ask_btc"
+    k1_iv: str = "k1_iv"
+    k2_iv: str = "k2_iv"
     net_ev_strategy1: str = "net_ev_strategy1"
     gross_ev_strategy1: str = "gross_ev_strategy1"
     total_cost_strategy1: str = "total_cost_strategy1"
@@ -100,6 +102,8 @@ class ResultsCsvHeader:
             self.k1_ask_btc,
             self.k2_bid_btc,
             self.k2_ask_btc,
+            self.k1_iv,
+            self.k2_iv,
             self.net_ev_strategy1,
             self.gross_ev_strategy1,
             self.total_cost_strategy1,


### PR DESCRIPTION
## Summary
- add strike quote structures to EV response so k1/k2 bid/ask and IV are exposed
- persist k1/k2 IV values in generated result rows for downstream EV calculations

## Testing
- python -m compileall src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d4729c984832197c54b6697d641ef)