### PR TITLE
Fix monitor imports and harden background refresh

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Core package initialization for the ProArb MVP tools."""

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -95,11 +95,12 @@ async def _background_loop() -> None:
     csv_path = _get_csv_path()
     logger.info("background loop starting refresh_seconds=%s csv=%s", REFRESH_SECONDS, csv_path)
 
-    refresh_cache(csv_path)
-
     while True:
+        try:
+            refresh_cache(csv_path)
+        except Exception as exc:
+            logger.exception("background refresh failed: %s", exc)
         await asyncio.sleep(REFRESH_SECONDS)
-        refresh_cache(csv_path)
 
 
 @app.on_event("startup")

--- a/src/early_exit_monitor.py
+++ b/src/early_exit_monitor.py
@@ -2,16 +2,17 @@ from __future__ import annotations
 
 import asyncio
 import csv
+import os
 from dataclasses import dataclass
 from datetime import datetime, date, timedelta, timezone
 from typing import List, Dict, Any, Optional, Literal
 
-from fetch_data.polymarket_client import (
+from .fetch_data.polymarket_client import (
     get_polymarket_slippage,
     PolymarketClient,
 )
-from utils.dataloader import load_all_configs
-from utils.save_result import RESULTS_CSV_HEADER, ensure_csv_file
+from .utils.dataloader import load_all_configs
+from .utils.save_result import RESULTS_CSV_HEADER, ensure_csv_file
 
 
 # ==================== 配置：路径 & 策略参数 ====================


### PR DESCRIPTION
## Summary
- adjust early exit monitor to use package-relative imports and add a package initializer for reliable module execution
- guard the API server background refresh loop with exception handling to keep it alive when CSV ingestion fails

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e4198e23883219f7dd9fcd4494a33)