### PR TITLE
Guard results.csv writes with lock and add tests

### DIFF
--- a/tests/test_save_result.py
+++ b/tests/test_save_result.py
@@ -1,0 +1,56 @@
+import csv
+import threading
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.utils.save_result import save_result_csv
+
+
+def test_save_result_csv_appends_rows(tmp_path):
+    csv_path = tmp_path / "results.csv"
+
+    rows = [
+        {"timestamp": "2024-01-01 00:00:00", "market_title": "m1"},
+        {"timestamp": "2024-01-01 00:00:01", "market_title": "m2", "extra": "x"},
+    ]
+
+    for row in rows:
+        save_result_csv(row, csv_path=str(csv_path))
+
+    with csv_path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        saved = list(reader)
+
+    assert len(saved) == len(rows)
+    assert saved[-1]["extra"] == "x"
+
+
+def test_save_result_csv_thread_safety(tmp_path):
+    csv_path = tmp_path / "results.csv"
+
+    def _writer(idx: int) -> None:
+        save_result_csv(
+            {
+                "timestamp": f"2024-01-01 00:00:{idx:02d}",
+                "market_title": f"m{idx}",
+                "value": idx,
+            },
+            csv_path=str(csv_path),
+        )
+
+    threads = [threading.Thread(target=_writer, args=(i,)) for i in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    with csv_path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        saved = list(reader)
+
+    assert len(saved) == 5
+    assert {row["market_title"] for row in saved} == {f"m{i}" for i in range(5)}


### PR DESCRIPTION
## Summary
- guard results.csv read/write cycles with a module-level lock and force flushes to avoid truncated output
- add unit coverage for result CSV appends and concurrent writes

## Testing
- pytest tests/test_save_result.py -q
- pytest -q *(fails: missing dependency pyyaml; pip install blocked by proxy)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e7d4e61348321a49f1c564b7ea0a2)