### PR TITLE
Fix results CSV header check

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -404,17 +404,20 @@ async def loop_event(
     # 确保数据目录/CSV 文件存在
     ensure_csv_file(output_csv, header=RESULTS_CSV_HEADER)
 
-    # 验证CSV表头是否正确（应该是55列）
+    # 验证CSV表头是否正确（使用当前 ResultsCsvHeader 长度）
     try:
         from pathlib import Path
         import csv
         csv_path = Path(output_csv)
+        expected_columns = len(RESULTS_CSV_HEADER.as_list())
         if csv_path.exists():
             with csv_path.open('r', encoding='utf-8') as f:
                 reader = csv.reader(f)
                 header = next(reader, [])
-                if len(header) != 55:
-                    console.print(f"[yellow]⚠️  检测到旧的CSV格式 ({len(header)}列)，重建为新格式 (55列)...[/yellow]")
+                if len(header) != expected_columns:
+                    console.print(
+                        f"[yellow]⚠️  检测到旧的CSV格式 ({len(header)}列)，重建为新格式 ({expected_columns}列)...[/yellow]"
+                    )
                     csv_path.unlink()
                     ensure_csv_file(output_csv, header=RESULTS_CSV_HEADER)
     except Exception:

--- a/tests/test_save_result.py
+++ b/tests/test_save_result.py
@@ -1,0 +1,56 @@
+import csv
+import threading
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.utils.save_result import save_result_csv
+
+
+def test_save_result_csv_appends_rows(tmp_path):
+    csv_path = tmp_path / "results.csv"
+
+    rows = [
+        {"timestamp": "2024-01-01 00:00:00", "market_title": "m1"},
+        {"timestamp": "2024-01-01 00:00:01", "market_title": "m2", "extra": "x"},
+    ]
+
+    for row in rows:
+        save_result_csv(row, csv_path=str(csv_path))
+
+    with csv_path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        saved = list(reader)
+
+    assert len(saved) == len(rows)
+    assert saved[-1]["extra"] == "x"
+
+
+def test_save_result_csv_thread_safety(tmp_path):
+    csv_path = tmp_path / "results.csv"
+
+    def _writer(idx: int) -> None:
+        save_result_csv(
+            {
+                "timestamp": f"2024-01-01 00:00:{idx:02d}",
+                "market_title": f"m{idx}",
+                "value": idx,
+            },
+            csv_path=str(csv_path),
+        )
+
+    threads = [threading.Thread(target=_writer, args=(i,)) for i in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    with csv_path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        saved = list(reader)
+
+    assert len(saved) == 5
+    assert {row["market_title"] for row in saved} == {f"m{i}" for i in range(5)}


### PR DESCRIPTION
## Summary
- validate results.csv headers against the current ResultsCsvHeader length instead of a hard-coded column count
- rebuild legacy CSVs using the dynamically computed column total so files stop being deleted each loop iteration

## Testing
- pytest tests/test_save_result.py -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e7d4e61348321a49f1c564b7ea0a2)