### PR TITLE
Add day_off configuration and validate target dates

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,7 @@ thresholds:
   min_net_ev: 0.0                 # 只接受正EV
   min_roi_pct: 0.0                # 只接受正ROI
   dry_trade: false                 # 自动交易是否走模拟模式
+  day_off: 1                      # 目标日期与今日的偏移（单位：天），例如今天 12/2、day_off=1 => 监控 12/3 市场
 
 events:
   - name: "BTC above ___ template"

--- a/src/utils/dataloader/config_loader.py
+++ b/src/utils/dataloader/config_loader.py
@@ -37,6 +37,7 @@ class ThresholdsConfig:
     min_net_ev: float
     min_roi_pct: float
     dry_trade: bool
+    day_off: int
 
 @dataclass
 class Config:
@@ -63,7 +64,8 @@ def load_config(config_path: str = os.getenv("CONFIG_PATH", "config.yaml")):
         max_pm_price=get_value_from_dict(row_config['thresholds'], 'max_pm_price'),
         min_net_ev=get_value_from_dict(row_config['thresholds'], 'min_net_ev'),
         min_roi_pct=get_value_from_dict(row_config['thresholds'], 'min_roi_pct'),
-        dry_trade=get_value_from_dict(row_config['thresholds'], 'dry_trade')
+        dry_trade=get_value_from_dict(row_config['thresholds'], 'dry_trade'),
+        day_off=get_value_from_dict(row_config['thresholds'], 'day_off')
     )
 
     events_config = [

--- a/src/utils/init_markets.py
+++ b/src/utils/init_markets.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from datetime import date, datetime, timezone
+from typing import Any, Dict, Optional, Tuple
 
 from ..fetch_data.deribit_client import DeribitClient
 
@@ -16,13 +16,17 @@ def parse_timestamp(exp: Any) -> Optional[float]:
     return None
 
 
-def init_markets(config: Dict[str, Any], day_offset: int = 0) -> Dict[str, Dict[str, Any]]:
+def init_markets(
+    config: Dict[str, Any], day_offset: int = 0, target_date: date | None = None
+) -> Tuple[Dict[str, Dict[str, Any]], list[str]]:
     """
     根据行权价为每个事件找出 Deribit 的 K1/K2 合约名，并记录资产类型 BTC / ETH。
 
     优先使用显式给出的到期时间（k1_expiration / k2_expiration），否则根据 day_offset 自动匹配。
+    若实际合约到期日与 target_date 不符，则跳过该市场。
     """
     instruments_map: Dict[str, Dict[str, Any]] = {}
+    skipped_titles: list[str] = []
 
     for m in config["events"]:
         title = m["polymarket"]["market_title"]
@@ -32,6 +36,8 @@ def init_markets(config: Dict[str, Any], day_offset: int = 0) -> Dict[str, Dict[
 
         k1_explicit = parse_timestamp(m["deribit"].get("k1_expiration"))
         k2_explicit = parse_timestamp(m["deribit"].get("k2_expiration"))
+
+        expected_expiration_date = target_date
 
         if k1_explicit and k2_explicit:
             inst_k1, k1_exp = DeribitClient.find_option_instrument(
@@ -46,6 +52,9 @@ def init_markets(config: Dict[str, Any], day_offset: int = 0) -> Dict[str, Dict[
                 currency=asset,
                 exp_timestamp=k2_explicit,
             )
+            expected_expiration_date = datetime.fromtimestamp(
+                k1_explicit / 1000.0, tz=timezone.utc
+            ).date()
         else:
             inst_k1, k1_exp = DeribitClient.find_option_instrument(
                 k1,
@@ -60,6 +69,14 @@ def init_markets(config: Dict[str, Any], day_offset: int = 0) -> Dict[str, Dict[
                 day_offset=day_offset,
             )
 
+        if expected_expiration_date:
+            actual_expiration_date = datetime.fromtimestamp(
+                k1_exp / 1000.0, tz=timezone.utc
+            ).date()
+            if actual_expiration_date != expected_expiration_date:
+                skipped_titles.append(title)
+                continue
+
         instruments_map[title] = {
             "k1": inst_k1,
             "k1_expiration_timestamp": k1_exp,
@@ -68,4 +85,4 @@ def init_markets(config: Dict[str, Any], day_offset: int = 0) -> Dict[str, Dict[
             "asset": asset,
         }
 
-    return instruments_map
+    return instruments_map, skipped_titles


### PR DESCRIPTION
## Summary
- add configurable day_off offset for selecting target trading date
- validate Deribit option expirations against the target date and skip mismatches
- expose day_off through config loading and update monitoring output

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ec7e069708321b536c6c6e26bc74e)