### PR TITLE
Switch Deribit monitoring to BTC-USDC options

### DIFF
--- a/src/fetch_data/deribit_client.py
+++ b/src/fetch_data/deribit_client.py
@@ -9,6 +9,7 @@ class Deribit_option_data:
     mark_iv: float
     bid_price: float
     ask_price: float
+    settlement_currency: str
     fee: float
 
 class DeribitClient:
@@ -16,12 +17,15 @@ class DeribitClient:
     def get_deribit_option_data(
         currency: str = "BTC",
         kind: str = "option",
+        settlement_currency: str | None = "USDC",
         base_fee_btc: float = 0.0003,
         base_fee_eth: float = 0.0003,
-        usdc_settled: bool = False,
+        usdc_settled: bool = True,
         amount: float = 1.0,
     ):
-        data = DeribitAPI.get_deribit_option_data(currency=currency, kind=kind)
+        data = DeribitAPI.get_deribit_option_data(
+            currency=currency, kind=kind, settlement_currency=settlement_currency
+        )
         results: list[Deribit_option_data] = []
         for item in data.get("result", []):
             try:
@@ -31,9 +35,12 @@ class DeribitClient:
                 ask_price = float(item.get("ask_price"))
                 option_price = float(item.get("last") or 0.0)
                 index_price = float(item.get("underlying_price"))
+                settlement = str(item.get("settlement_currency") or "").upper() or "BTC"
+
+                is_usdc_settled = settlement == "USDC" if settlement_currency else usdc_settled
 
                 # 手续费计算逻辑
-                if not usdc_settled:
+                if not is_usdc_settled:
                     base_fee = base_fee_btc if currency.upper() == "BTC" else base_fee_eth
                     fee = max(base_fee, 0.125 * option_price) * amount
                 else:
@@ -41,10 +48,11 @@ class DeribitClient:
 
                 results.append(
                     Deribit_option_data(
-                        instrument_name=option_name, 
-                        mark_iv=mark_iv, 
-                        bid_price=bid_price, 
-                        ask_price=ask_price, 
+                        instrument_name=option_name,
+                        mark_iv=mark_iv,
+                        bid_price=bid_price,
+                        ask_price=ask_price,
+                        settlement_currency=settlement,
                         fee=fee
                     )
                 )
@@ -61,11 +69,13 @@ class DeribitClient:
         call: bool = True,
         day_offset: int = 0,
         exp_timestamp: float | None = None,
+        settlement_currency: Literal["BTC", "USDC"] | None = "USDC",
     ):
         return DeribitAPI.find_option_instrument(
-            strike=strike, 
-            currency=currency, 
-            call=call, 
-            day_offset=day_offset, 
-            exp_timestamp=exp_timestamp
+            strike=strike,
+            currency=currency,
+            call=call,
+            day_offset=day_offset,
+            exp_timestamp=exp_timestamp,
+            settlement_currency=settlement_currency,
         )

--- a/src/utils/init_markets.py
+++ b/src/utils/init_markets.py
@@ -45,12 +45,14 @@ def init_markets(
                 call=True,
                 currency=asset,
                 exp_timestamp=k1_explicit,
+                settlement_currency="USDC",
             )
             inst_k2, k2_exp = DeribitClient.find_option_instrument(
                 k2,
                 call=True,
                 currency=asset,
                 exp_timestamp=k2_explicit,
+                settlement_currency="USDC",
             )
             expected_expiration_date = datetime.fromtimestamp(
                 k1_explicit / 1000.0, tz=timezone.utc
@@ -61,12 +63,14 @@ def init_markets(
                 call=True,
                 currency=asset,
                 day_offset=day_offset,
+                settlement_currency="USDC",
             )
             inst_k2, k2_exp = DeribitClient.find_option_instrument(
                 k2,
                 call=True,
                 currency=asset,
                 day_offset=day_offset,
+                settlement_currency="USDC",
             )
 
         if expected_expiration_date:


### PR DESCRIPTION
## Summary
- Filter Deribit instrument discovery and book summaries to prefer USDC-settled BTC options
- Update market initialization and context building to select BTC-USDC contracts explicitly
- Adjust quote handling and fee estimates for USDC-settled option pricing

## Testing
- python -m compileall src


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693142ac25f88321aab2938c97f8aeb0)