### PR TITLE
Add hourly Telegram GET endpoint broadcasts

### DIFF
--- a/src/telegram/TG_bot.py
+++ b/src/telegram/TG_bot.py
@@ -1,11 +1,12 @@
 from .telegramNotifier import TelegramNotifier
 
+
 class TG_bot:
     def __init__(self, name: str, token: str, chat_id: str):
         self.name = name
-
         self.notifier = TelegramNotifier(token=token, chat_id=chat_id)
 
     async def publish(self, msg: str):
         success, msg_id = await self.notifier.send_message(text=msg)
         return success, msg_id
+


### PR DESCRIPTION
## Summary
- add an hourly background task to broadcast available GET API endpoints to configured Telegram bots
- build Telegram bot initialization that respects alert/trading bot settings and guards missing configuration
- clean up the Telegram bot wrapper formatting

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932ada95a788321b391b2f38870426a)