### PR TITLE
Add contract rounding band configuration for monitoring

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,7 @@ thresholds:
   check_interval_sec: 10
   INVESTMENTS: [200]
   min_contract_size: 0.1          #Deribit最小合约单位（BTC）
+  contract_rounding_band: 1       # 合约数四舍五入窗口（1 表示允许四舍五入到 0.1 ± 0.01，2 表示 ± 0.02）
   min_pm_price: 0.01              # PM价格 < 0.01 拒绝
   max_pm_price: 0.99              # PM价格 > 0.99 拒绝
   min_net_ev: 0.0                 # 只接受正EV

--- a/src/main.py
+++ b/src/main.py
@@ -398,6 +398,7 @@ async def loop_event(
     net_ev_min = float(thresholds.get("notify_net_ev_min", 0.0))  # 可选：不配就默认 0
     cooldown_sec = float(thresholds.get("telegram_opportunity_cooldown_sec", 300))  # 可选：默认 5 分钟
     min_contract_size = float(thresholds.get("min_contract_size", 0.0))
+    contract_rounding_band = int(thresholds.get("contract_rounding_band", 0))
     min_pm_price = float(thresholds.get("min_pm_price", 0.0))
     max_pm_price = float(thresholds.get("max_pm_price", 1.0))
     dry_trade_mode = bool(thresholds.get("dry_trade", False))
@@ -496,6 +497,22 @@ async def loop_event(
             roi_str = f"{roi_pct:.2f}%"
 
             contracts_strategy2 = float(result.contracts_strategy2)
+            rounding_tolerance = contract_rounding_band * 0.01
+            if contract_rounding_band > 0:
+                rounded_contracts = round(contracts_strategy2 * 10) / 10.0
+                lower_bound = rounded_contracts - rounding_tolerance
+                upper_bound = rounded_contracts + rounding_tolerance
+
+                if lower_bound <= contracts_strategy2 <= upper_bound:
+                    contracts_strategy2 = rounded_contracts
+                    result.contracts_strategy2 = contracts_strategy2
+                else:
+                    validation_errors.append(
+                        (
+                            f"合约数 {contracts_strategy2:.4f} 不在允许的 "
+                            f"{rounded_contracts:.1f} ± {rounding_tolerance:.2f} 范围内"
+                        )
+                    )
 
             signal_key = f"{deribit_ctx.asset}:{int(round(deribit_ctx.K_poly))}:{inv_base_usd:.0f}"
             previous_snapshot = signal_state.get(signal_key)
@@ -519,10 +536,6 @@ async def loop_event(
             if contracts_strategy2 < min_contract_size:
                 validation_errors.append(
                     f"合约数 {contracts_strategy2:.4f} 小于最小合约单位 {min_contract_size}"
-                )
-            if int(abs(contracts_strategy2) * 100) % 10 < 5:
-                validation_errors.append(
-                    f"合约数 {contracts_strategy2:.4f} 小数点后第二位 小于 5"
                 )
             if pm_price < min_pm_price:
                 validation_errors.append(


### PR DESCRIPTION
## Summary
- add a configurable `contract_rounding_band` threshold to control contract rounding windows
- enforce the rounding band in the main monitor, rounding within the allowed window and skipping trades outside it

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932b1d9dea08321ab7535174f30508a)