### PR TITLE
Record theoretical contract sizes in positions logs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,7 @@ thresholds:
   check_interval_sec: 10
   INVESTMENTS: [200]
   min_contract_size: 0.1          #Deribit最小合约单位（BTC）
+  contract_rounding_band: 1       # 合约数四舍五入窗口（1 表示允许四舍五入到 0.1 ± 0.01，2 表示 ± 0.02）
   min_pm_price: 0.01              # PM价格 < 0.01 拒绝
   max_pm_price: 0.99              # PM价格 > 0.99 拒绝
   min_net_ev: 0.0                 # 只接受正EV

--- a/src/services/trade_service.py
+++ b/src/services/trade_service.py
@@ -464,6 +464,10 @@ async def execute_trade(*, csv_path: str, market_id: str, investment_usd: float,
     # 计算 PM token 数量
     pm_tokens = investment_usd / limit_price if limit_price > 0 else 0.0
 
+    theoretical_contracts = _safe_float(
+        row.get(f"contracts_strategy{strategy}_theoretical"), default=contracts
+    )
+
     position_data = {
         # 基础信息
         "trade_id": tx_id,
@@ -481,6 +485,7 @@ async def execute_trade(*, csv_path: str, market_id: str, investment_usd: float,
 
         # DR 头寸信息
         "contracts": contracts,
+        "contracts_theoretical": theoretical_contracts,
         "dr_entry_cost": dr_entry_cost,
         "inst_k1": inst_k1,
         "inst_k2": inst_k2,

--- a/src/utils/save_result.py
+++ b/src/utils/save_result.py
@@ -150,6 +150,7 @@ POSITIONS_CSV_HEADER = [
 
     # DR 头寸信息
     "contracts",           # Deribit 合约数量
+    "contracts_theoretical",  # 未经四舍五入的理论合约数
     "dr_entry_cost",       # DR 端入场成本（可为负=净收入）
     "inst_k1",             # Deribit K1 合约名
     "inst_k2",             # Deribit K2 合约名


### PR DESCRIPTION
## Summary
- capture the unrounded strategy 2 contract size and persist it alongside rounded values
- extend positions.csv schema and trade logging to store theoretical contracts for executed trades

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932b1d9dea08321ab7535174f30508a)