### PR TITLE
Use load_all_configs for configuration access

### DIFF
--- a/src/services/trade_service.py
+++ b/src/services/trade_service.py
@@ -4,7 +4,6 @@ import asyncio
 import csv
 import logging
 from datetime import datetime, timezone
-import os
 import time
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
@@ -18,7 +17,6 @@ from ..trading.deribit_trade import DeribitUserCfg
 from ..trading.deribit_trade_client import Deribit_trade_client
 from ..trading.polymarket_trade_client import Polymarket_trade_client
 from .api_models import TradeResult
-from dotenv import load_dotenv
 
 # ---------- errors ----------
 
@@ -513,8 +511,8 @@ async def execute_trade(*, csv_path: str, market_id: str, investment_usd: float,
     if should_record_signal:
         # --- Telegram: trade log (Bot2) ---
         try:
-            trading_token = str(os.getenv("TELEGRAM_BOT_TOKEN_TRADING"))
-            chat_id = str(os.getenv("TELEGRAM_CHAT_ID"))
+            trading_token = str(env.TELEGRAM_BOT_TOKEN_TRADING)
+            chat_id = str(env.TELEGRAM_CHAT_ID)
             trading_bot = TG_bot(name="trading", token=trading_token, chat_id=chat_id)
 
             asset = str(row.get("asset") or "")

--- a/src/telegram/telegramNotifier.py
+++ b/src/telegram/telegramNotifier.py
@@ -7,18 +7,21 @@ TelegramNotifier: 用于通过 Telegram Bot API 发送消息.
 需要传参 token 和 chat_id, 或者通过环境变量 TELEGRAM_TOKEN 和 TELEGRAM_CHAT_ID 提供.
 """
 import logging
-import os
 from typing import Any, Dict, Optional, Tuple
 
 import aiohttp
+
+from src.utils.dataloader import load_all_configs
 
 
 class TelegramNotifier:
     logger = logging.getLogger(__name__)
 
     def __init__(self, token: Optional[str] = None, chat_id: Optional[str] = None):
-        self.token = token or os.getenv("TELEGRAM_TOKEN")
-        self.chat_id = chat_id or os.getenv("TELEGRAM_CHAT_ID")
+        env_config, _, _ = load_all_configs()
+
+        self.token = token or env_config.TELEGRAM_TOKEN
+        self.chat_id = chat_id or env_config.TELEGRAM_CHAT_ID
         # 验证必要参数否则抛出异常
         if not self.token or not self.chat_id:
             raise ValueError("TELEGRAM_TOKEN 或 TELEGRAM_CHAT_ID 未配置")

--- a/src/trading/polymarket_trade.py
+++ b/src/trading/polymarket_trade.py
@@ -1,29 +1,38 @@
-import os
 from dataclasses import dataclass
 from typing import Any, Dict, Literal, Optional
 
-from dotenv import load_dotenv
 from py_clob_client.client import ClobClient, PolyException
 from py_clob_client.clob_types import OrderArgs
 
-load_dotenv()
+from ..utils.dataloader import Env_config, load_all_configs
+
+
+_ENV_CONFIG: Env_config | None = None
+
+
+def _get_env_config() -> Env_config:
+    global _ENV_CONFIG
+    if _ENV_CONFIG is None:
+        _ENV_CONFIG, _, _ = load_all_configs()
+    return _ENV_CONFIG
+
 
 @dataclass
 class PolymarketClientCfg:
     proxy_address: str
     private_key: str
-    host: str="https://clob.polymarket.com"
-    chain_id: int=137
+    host: str = "https://clob.polymarket.com"
+    chain_id: int = 137
+
 
 class Polymarket_trade:
     @staticmethod
     def get_client() -> ClobClient:
-        private_key = os.getenv("polymarket_secret")
-        proxy_address = os.getenv("POLYMARKET_PROXY_ADDRESS")
+        env_config = _get_env_config()
 
         cfg = PolymarketClientCfg(
-            private_key=str(private_key),
-            proxy_address=str(proxy_address),
+            private_key=str(env_config.polymarket_secret),
+            proxy_address=str(env_config.POLYMARKET_PROXY_ADDRESS),
         )
 
         client = ClobClient(

--- a/src/utils/auth.py
+++ b/src/utils/auth.py
@@ -8,11 +8,12 @@ surface small to make it easy to audit what gets sent to the signer service.
 from __future__ import annotations
 
 import logging
-import os
 from typing import Any, Dict
 
 import requests
 from web3 import Web3
+
+from .dataloader import Env_config, load_all_configs
 
 
 class SigningError(RuntimeError):
@@ -21,13 +22,22 @@ class SigningError(RuntimeError):
 
 logger = logging.getLogger(__name__)
 
+_ENV_CONFIG: Env_config | None = None
+
+
+def _get_env_config() -> Env_config:
+    global _ENV_CONFIG
+    if _ENV_CONFIG is None:
+        _ENV_CONFIG, _, _ = load_all_configs()
+    return _ENV_CONFIG
+
 
 def get_signer_url() -> str:
-    return os.getenv("SIGNER_URL", "")
+    return _get_env_config().SIGNER_URL
 
 
 def get_signing_token(*, required: bool = True) -> str | None:
-    token = os.getenv("SIGNING_TOKEN")
+    token = _get_env_config().SIGNING_TOKEN
     if required and not token:
         raise SigningError("SIGNING_TOKEN is required for remote signing")
     return token

--- a/src/utils/dataloader/env_loader.py
+++ b/src/utils/dataloader/env_loader.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 import dotenv
 import os
@@ -19,6 +20,9 @@ class Env_config:
     polymarket_secret: str
     POLYMARKET_PROXY_ADDRESS: str
 
+    SIGNER_URL: str
+    SIGNING_TOKEN: Optional[str]
+
     TELEGRAM_ENABLED: bool
     TELEGRAM_ALART_ENABLED: bool
     TELEGRAM_TRADING_ENABLED: bool
@@ -26,6 +30,7 @@ class Env_config:
     TELEGRAM_BOT_TOKEN_ALERT: str
     TELEGRAM_BOT_TOKEN_TRADING: str
     TELEGRAM_CHAT_ID: str
+    TELEGRAM_TOKEN: Optional[str]
 
     MAX_RETRIES: int
     RETRY_DELAY_SECONDS: int
@@ -68,12 +73,15 @@ def load_env_config():
                 "0x1bD027BCA18bCe3dC541850FB42b789439b36B6D",
             )
         ),
+        SIGNER_URL=str(_get_optional_env("SIGNER_URL", "")),
+        SIGNING_TOKEN=str(_get_optional_env("SIGNING_TOKEN", "")) or None,
         TELEGRAM_ENABLED=bool(get_value_from_env("TELEGRAM_ENABLED")),
         TELEGRAM_ALART_ENABLED=bool(get_value_from_env("TELEGRAM_ALART_ENABLED")),
         TELEGRAM_TRADING_ENABLED=bool(get_value_from_env("TELEGRAM_TRADING_ENABLED")),
         TELEGRAM_BOT_TOKEN_ALERT=str(get_value_from_env("TELEGRAM_BOT_TOKEN_ALERT")),
         TELEGRAM_BOT_TOKEN_TRADING=str(get_value_from_env("TELEGRAM_BOT_TOKEN_TRADING")),
         TELEGRAM_CHAT_ID=str(get_value_from_env("TELEGRAM_CHAT_ID")),
+        TELEGRAM_TOKEN=str(_get_optional_env("TELEGRAM_TOKEN", "")) or None,
         MAX_RETRIES=int(get_value_from_env("MAX_RETRIES")),
         RETRY_DELAY_SECONDS=int(get_value_from_env("RETRY_DELAY_SECONDS")),
         RETRY_BACKOFF=int(get_value_from_env("RETRY_BACKOFF")),


### PR DESCRIPTION
## Summary
- extend the shared environment configuration loader to include signer and Telegram fields and optional defaults
- update services, trading utilities, monitoring, and Telegram helpers to read environment data exclusively via `load_all_configs`

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932ffc771148321a348141c6458478e)