### PR TITLE
Adjust contract rounding band to percentage-based tolerance

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,7 +9,7 @@ thresholds:
   INVESTMENTS: [200]              # 一笔的投资金额
   dry_trade: false                # 交易是否走模拟模式
   min_contract_size: 0.1          # Deribit最小合约单位（BTC）
-  contract_rounding_band: 1       # 合约数调整范围系数；1 表示允许在目标合约数的 ±10% 内四舍五入到最接近的 0.1
+  contract_rounding_band: 3       # 合约数调整范围系数；1 表示允许在目标合约数的 ±10% 内四舍五入到最接近的 0.1（当前值 3 = ±30%）
   min_pm_price: 0.01              # PM价格 < 0.01 拒绝
   max_pm_price: 0.99              # PM价格 > 0.99 拒绝
   min_net_ev: 0.0                 # 只接受正EV

--- a/config.yaml
+++ b/config.yaml
@@ -9,7 +9,7 @@ thresholds:
   INVESTMENTS: [200]              # 一笔的投资金额
   dry_trade: false                # 交易是否走模拟模式
   min_contract_size: 0.1          # Deribit最小合约单位（BTC）
-  contract_rounding_band: 3       # 合约数四舍五入窗口（1 表示允许四舍五入到 0.1 ± 0.01，2 表示 ± 0.02）
+  contract_rounding_band: 1       # 合约数调整范围系数；1 表示允许在目标合约数的 ±10% 内四舍五入到最接近的 0.1
   min_pm_price: 0.01              # PM价格 < 0.01 拒绝
   max_pm_price: 0.99              # PM价格 > 0.99 拒绝
   min_net_ev: 0.0                 # 只接受正EV

--- a/src/main.py
+++ b/src/main.py
@@ -412,7 +412,7 @@ async def loop_event(
     prob_edge_min = float(thresholds.ev_spread_min)
     net_ev_min = float(thresholds.notify_net_ev_min)  # 可选：不配就默认 0
     min_contract_size = float(thresholds.min_contract_size)
-    contract_rounding_band = int(thresholds.contract_rounding_band)
+    contract_rounding_band = float(thresholds.contract_rounding_band)
     min_pm_price = float(thresholds.min_pm_price)
     max_pm_price = float(thresholds.max_pm_price)
     dry_trade_mode = bool(thresholds.dry_trade)
@@ -513,9 +513,9 @@ async def loop_event(
             validation_errors = []
             contracts_strategy2 = float(result.contracts_strategy2)
             theoretical_contracts_strategy2 = contracts_strategy2
-            rounding_tolerance = contract_rounding_band * 0.01
             if contract_rounding_band > 0:
                 rounded_contracts = round(contracts_strategy2 * 10) / 10.0
+                rounding_tolerance = rounded_contracts * contract_rounding_band * 0.1
                 lower_bound = rounded_contracts - rounding_tolerance
                 upper_bound = rounded_contracts + rounding_tolerance
 

--- a/src/utils/dataloader/config_loader.py
+++ b/src/utils/dataloader/config_loader.py
@@ -32,7 +32,7 @@ class ThresholdsConfig:
     check_interval_sec: int
     INVESTMENTS: List[int]
     min_contract_size: float
-    contract_rounding_band: int
+    contract_rounding_band: float
     min_pm_price: float
     max_pm_price: float
     min_net_ev: float


### PR DESCRIPTION
## Summary
- interpret `contract_rounding_band` as a percentage-based adjustment factor for rounding contract counts to the nearest tenth
- apply tolerance relative to the rounded contract amount and allow fractional band configuration values
- update the configuration comment to reflect the new contract adjustment range meaning

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69339c9c679083219f737df808e1b991)