### PR TITLE
Fix scientific notation bug in CSV storage

### DIFF
--- a/fix_existing_csv.py
+++ b/fix_existing_csv.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""修复现有 positions.csv 文件中的科学计数法问题"""
+
+import csv
+import re
+from pathlib import Path
+
+def has_scientific_notation(value: str) -> bool:
+    """检查字符串是否包含科学计数法"""
+    return bool(re.search(r'\d+\.?\d*e[+-]?\d+', str(value).lower()))
+
+def convert_scientific_to_int(value: str) -> str:
+    """尝试将科学计数法转换为整数字符串"""
+    try:
+        # 如果是科学计数法，转换为浮点数再转为整数字符串
+        if has_scientific_notation(value):
+            num = float(value)
+            # 如果是整数，转换为整数字符串（去除小数点）
+            if num == int(num):
+                return str(int(num))
+            else:
+                # 如果有小数部分，保留浮点数格式
+                return str(num)
+        return value
+    except (ValueError, OverflowError):
+        # 转换失败，返回原值
+        return value
+
+def fix_csv_file(csv_path: str, backup: bool = True):
+    """
+    修复 CSV 文件中的科学计数法问题
+
+    Args:
+        csv_path: CSV 文件路径
+        backup: 是否创建备份文件
+    """
+    path = Path(csv_path)
+
+    if not path.exists():
+        print(f"❌ 文件不存在: {csv_path}")
+        return False
+
+    print(f"🔍 检查文件: {csv_path}")
+
+    # 读取文件
+    with open(path, 'r', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        fieldnames = reader.fieldnames
+        rows = list(reader)
+
+    if not rows:
+        print("⚠️  文件为空，无需修复")
+        return True
+
+    # 检查哪些字段包含科学计数法
+    fields_with_scientific = set()
+    fixed_count = 0
+
+    for row in rows:
+        for field, value in row.items():
+            if value and has_scientific_notation(value):
+                fields_with_scientific.add(field)
+
+    if not fields_with_scientific:
+        print("✅ 未检测到科学计数法，无需修复")
+        return True
+
+    print(f"⚠️  检测到以下字段包含科学计数法: {fields_with_scientific}")
+
+    # 创建备份
+    if backup:
+        backup_path = path.with_suffix('.csv.backup')
+        import shutil
+        shutil.copy2(path, backup_path)
+        print(f"📦 已创建备份: {backup_path}")
+
+    # 修复数据
+    print("\n🔧 开始修复...")
+    for row in rows:
+        for field in fields_with_scientific:
+            if field in row and row[field]:
+                old_value = row[field]
+                new_value = convert_scientific_to_int(old_value)
+                if old_value != new_value:
+                    print(f"  {field}: {old_value} → {new_value}")
+                    row[field] = new_value
+                    fixed_count += 1
+
+    # 写回文件（使用 QUOTE_NONNUMERIC 防止再次出现问题）
+    with open(path, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, quoting=csv.QUOTE_NONNUMERIC)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    print(f"\n✅ 修复完成! 共修复 {fixed_count} 个字段")
+    print(f"📄 已更新文件: {csv_path}")
+
+    return True
+
+def main():
+    """主函数"""
+    positions_csv = "./data/positions.csv"
+
+    print("=" * 60)
+    print("CSV 科学计数法修复工具")
+    print("=" * 60)
+    print()
+
+    # 检查文件是否存在
+    if not Path(positions_csv).exists():
+        print(f"ℹ️  文件不存在: {positions_csv}")
+        print("   如果这是新项目，无需修复。")
+        return
+
+    # 修复文件
+    fix_csv_file(positions_csv, backup=True)
+
+    print()
+    print("=" * 60)
+    print("提示:")
+    print("  - 如果原始数据已损坏，可能无法完全恢复")
+    print("  - 科学计数法如 8.81318e+76 可能已丢失精度")
+    print("  - 建议检查修复后的数据是否正确")
+    print("  - 备份文件保存为: positions.csv.backup")
+    print("=" * 60)
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(f"\n❌ 错误: {e}")
+        import traceback
+        traceback.print_exc()
+        exit(1)

--- a/src/api/position.py
+++ b/src/api/position.py
@@ -80,6 +80,15 @@ def filter_positions_by_time(
 # 获取 positions.csv 的期望列
 POSITIONS_EXPECTED_COLUMNS = [f.name for f in fields(SavePosition)]
 
+# 定义 token_id 等字段的数据类型（防止大整数被转换为科学计数法）
+POSITIONS_DTYPE_SPEC = {
+    "yes_token_id": str,
+    "no_token_id": str,
+    "event_id": str,
+    "market_id": str,
+    "trade_id": str
+}
+
 def transform_position_row(row: dict) -> dict:
     """将 CSV 平铺数据转换为嵌套的 PositionResponse 格式"""
     # 解析 tuple 字符串
@@ -167,9 +176,9 @@ def get_position(
         仓位数据列表
     """
     # 检查并确保 CSV 文件包含所有必需的列
-    CsvHandler.check_csv('./data/positions.csv', POSITIONS_EXPECTED_COLUMNS, fill_value=0.0)
+    CsvHandler.check_csv('./data/positions.csv', POSITIONS_EXPECTED_COLUMNS, fill_value=0.0, dtype=POSITIONS_DTYPE_SPEC)
 
-    pos_df = pd.read_csv('./data/positions.csv')
+    pos_df = pd.read_csv('./data/positions.csv', dtype=POSITIONS_DTYPE_SPEC, low_memory=False)
 
     if pos_df.empty:
         return []
@@ -210,9 +219,9 @@ def get_closed_positions(
         已关闭仓位数据列表
     """
     # 检查并确保 CSV 文件包含所有必需的列
-    CsvHandler.check_csv('./data/positions.csv', POSITIONS_EXPECTED_COLUMNS, fill_value=0.0)
+    CsvHandler.check_csv('./data/positions.csv', POSITIONS_EXPECTED_COLUMNS, fill_value=0.0, dtype=POSITIONS_DTYPE_SPEC)
 
-    pos_df = pd.read_csv('./data/positions.csv')
+    pos_df = pd.read_csv('./data/positions.csv', dtype=POSITIONS_DTYPE_SPEC, low_memory=False)
 
     if pos_df.empty:
         return []

--- a/src/main.py
+++ b/src/main.py
@@ -510,12 +510,21 @@ async def early_exit_monitor():
     positions_csv = "./data/positions.csv"
     positions_columns = [f.name for f in fields(SavePosition)]
 
-    # 检查并确保 positions.csv 包含所有必需的列
-    CsvHandler.check_csv(positions_csv, positions_columns, fill_value=0.0)
+    # 定义 token_id 列的数据类型为字符串（防止大整数被转换为科学计数法）
+    dtype_spec = {
+        "yes_token_id": str,
+        "no_token_id": str,
+        "event_id": str,
+        "market_id": str,
+        "trade_id": str
+    }
 
-    csv_df = pd.read_csv(positions_csv)
+    # 检查并确保 positions.csv 包含所有必需的列
+    CsvHandler.check_csv(positions_csv, positions_columns, fill_value=0.0, dtype=dtype_spec)
+
+    csv_df = pd.read_csv(positions_csv, dtype=dtype_spec, low_memory=False)
     csv_df = csv_df.apply(earlt_exit_process_row, axis=1)
-    csv_df.to_csv(positions_csv, index=False)
+    csv_df.to_csv(positions_csv, index=False, quoting=csv.QUOTE_NONNUMERIC)
 
 async def main():
     # 读取配置, 已含检查 env, config, trading_config 是否存在


### PR DESCRIPTION
修复 CSV 文件中 token_id 字段被保存为科学计数法的问题

## 问题描述
在 positions.csv 中，yes_token_id 和 no_token_id 等大整数字段被保存为科学计数法格式（如 8.81318e+76），导致后续读取和使用时出现 bug。

## 根本原因
1. pandas.read_csv() 默认会自动推断数据类型，将大整数识别为浮点数
2. CSV 写入时没有指定引用策略，浮点数被格式化为科学计数法

## 解决方案
1. **CsvHandler.check_csv()**:
   - 添加 `dtype` 参数，允许指定列的数据类型
   - 使用 `dtype` 参数读取 CSV，强制 token_id 字段为字符串
   - 保存时使用 `csv.QUOTE_NONNUMERIC` 确保字符串被正确引用

2. **CsvHandler.save_to_csv()**:
   - 在保存前将字符串类型字段转换为字符串
   - 使用 `csv.QUOTE_NONNUMERIC` 写入

3. **main.py early_exit_monitor()**:
   - 定义 `dtype_spec` 指定 token_id 等字段为字符串
   - 在 `check_csv()` 和 `read_csv()` 中使用 dtype
   - 保存时使用 `csv.QUOTE_NONNUMERIC`

4. **api/position.py**:
   - 定义 `POSITIONS_DTYPE_SPEC` 常量
   - 在所有 `read_csv()` 调用中使用 dtype

## 变更文件
- src/utils/CsvHandler.py
- src/main.py
- src/api/position.py

## 测试
- 创建测试脚本验证大整数不再被转换为科学计数法
- 创建修复工具 `fix_existing_csv.py` 用于修复已损坏的 CSV 文件

Fixes issue with token_id fields being saved as scientific notation in CSV files