### PR TITLE
Add funding USD to PNL endpoint and filter by status

### DIFF
--- a/src/api/models.py
+++ b/src/api/models.py
@@ -209,7 +209,7 @@ class PnlPositionDetail(BaseModel):
 class PnlSummaryResponse(BaseModel):
     """PnL 汇总响应"""
     timestamp: str                           # 计算时间
-    total_positions: int                     # OPEN 仓位数量
+    total_positions: int                     # 仓位数量
 
     # 汇总财务指标
     total_cost_basis_usd: float              # 总投入成本
@@ -217,6 +217,7 @@ class PnlSummaryResponse(BaseModel):
     total_pm_pnl_usd: float                  # PM 部分总盈亏
     total_dr_pnl_usd: float                  # Deribit 部分总盈亏
     total_currency_pnl_usd: float            # 币价波动总盈亏
+    total_funding_usd: float                 # Net funding payments on Deribit (for hedging vs spot BTC)
     total_ev_usd: float                      # 模型预测总 EV
 
     # 汇总账本

--- a/src/utils/save_position.py
+++ b/src/utils/save_position.py
@@ -135,6 +135,7 @@ class SavePosition:
     ev_theta_adj_usd: float       # 时间修正后的毛利润
     ev_model_usd: float           # 净利润 (扣除手续费和滑点)
     roi_model_pct: float          # ROI 百分比
+    funding_usd: float            # Net funding payments on Deribit (for hedging vs spot BTC holdings)
 
 def save_position(
         dry_run: bool,
@@ -154,7 +155,8 @@ def save_position(
         slippage_pct: float,
         gross_ev: float,
         net_ev: float,
-        roi_pct: float
+        roi_pct: float,
+        funding_usd: float = 0.0  # Net funding payments on Deribit
     ):
     # 获取 K1 和 K2 的 ticker 数据
     k1_delta, k1_theta, k2_delta, k2_theta, settlement_price = 0.0, 0.0, 0.0, 0.0, 0.0
@@ -288,6 +290,7 @@ def save_position(
         ev_theta_adj_usd=gross_ev,  # theta adjustment 已包含在 gross_ev 中
         ev_model_usd=net_ev,
         roi_model_pct=roi_pct,
+        funding_usd=funding_usd,
     )
 
     CsvHandler.save_to_csv(csv_path, row_dict=asdict(row_obj), class_obj=SavePosition)


### PR DESCRIPTION
- Add funding_usd field to SavePosition dataclass for tracking net funding payments on Deribit (for hedging vs spot BTC holdings)
- Add total_funding_usd to PnlSummaryResponse model
- Change /api/pnl to return all positions by default instead of only OPEN
- Add status query parameter to filter by 'open' (未到期) or 'close' (已到期)