### PR TITLE
fix: return latest data per market instead of global latest timestamp

### DIFF
--- a/src/api/db.py
+++ b/src/api/db.py
@@ -274,14 +274,13 @@ async def get_db_market_data() -> List[DBRespone]:
         if df.empty:
             return []
 
-        # 找到最新的时间戳
-        if 'utc' in df.columns:
-            # 获取最新的时间戳
-            max_utc = df['utc'].max()
-            # 只保留最新时间戳的数据
-            df = df[df['utc'] == max_utc]
+        # 对每个市场，获取最新的数据
+        if 'utc' in df.columns and 'market_id' in df.columns:
+            # 按 market_id 分组，获取每个市场的最新时间戳
+            df = df.sort_values('utc', ascending=False)
+            df = df.groupby('market_id', as_index=False).first()
         else:
-            # 如果没有 utc 字段，只返回最后一行
+            # 如果没有必要字段，只返回最后一行
             df = df.tail(1)
 
         # 转换为响应对象

--- a/src/api/pm.py
+++ b/src/api/pm.py
@@ -177,14 +177,13 @@ async def get_pm_market_data() -> List[PMResponse]:
         if df.empty:
             return []
 
-        # 找到最新的时间戳
-        if 'utc' in df.columns:
-            # 获取最新的时间戳
-            max_utc = df['utc'].max()
-            # 只保留最新时间戳的数据
-            df = df[df['utc'] == max_utc]
+        # 对每个市场，获取最新的数据
+        if 'utc' in df.columns and 'market_id' in df.columns:
+            # 按 market_id 分组，获取每个市场的最新时间戳
+            df = df.sort_values('utc', ascending=False)
+            df = df.groupby('market_id', as_index=False).first()
         else:
-            # 如果没有 utc 字段，只返回最后一行
+            # 如果没有必要字段，只返回最后一行
             df = df.tail(1)
 
         # 转换为响应对象


### PR DESCRIPTION
- Changed logic to group by market_id and get the latest record for each market
- Each market now returns its own most recent data point
- This ensures all markets are represented with their current state
- Previous approach only returned markets that had data at the global max timestamp

Implementation:
- Sort by utc descending
- Group by market_id
- Take first (latest) record per group
- Returns the most recent snapshot for each individual market