### PR TITLE
fix: remove deprecated TELEGRAM_TOKEN field from env_loader

### DIFF
--- a/src/utils/loadAllConfig/env_loader.py
+++ b/src/utils/loadAllConfig/env_loader.py
@@ -26,7 +26,6 @@ class Env_config:
     TELEGRAM_BOT_TOKEN_ALERT: str
     TELEGRAM_BOT_TOKEN_TRADING: str
     TELEGRAM_CHAT_ID: str
-    TELEGRAM_TOKEN: str
 
     MAX_RETRIES: int
     RETRY_DELAY_SECONDS: int
@@ -52,7 +51,6 @@ def parse_env_config(env: Mapping[str, str]) -> Env_config:
         TELEGRAM_BOT_TOKEN_ALERT=str(get_value_from_dict(env, "TELEGRAM_BOT_TOKEN_ALERT")),
         TELEGRAM_BOT_TOKEN_TRADING=str(get_value_from_dict(env, "TELEGRAM_BOT_TOKEN_TRADING")),
         TELEGRAM_CHAT_ID=str(get_value_from_dict(env, "TELEGRAM_CHAT_ID")),
-        TELEGRAM_TOKEN=str(get_value_from_dict(env, "TELEGRAM_TOKEN")),
 
         MAX_RETRIES=int(get_value_from_dict(env, "MAX_RETRIES")),
         RETRY_DELAY_SECONDS=int(get_value_from_dict(env, "RETRY_DELAY_SECONDS")),

--- a/tests/utils/loadAllConfig/test_env_loader.py
+++ b/tests/utils/loadAllConfig/test_env_loader.py
@@ -15,7 +15,6 @@ def test_parse_env_config():
         "TELEGRAM_BOT_TOKEN_ALERT": "a",
         "TELEGRAM_BOT_TOKEN_TRADING": "b",
         "TELEGRAM_CHAT_ID": "1",
-        "TELEGRAM_TOKEN": "t",
         "MAX_RETRIES": "3",
         "RETRY_DELAY_SECONDS": "5",
         "RETRY_BACKOFF": "2",


### PR DESCRIPTION
The TELEGRAM_TOKEN field was a legacy configuration that is no longer used in the codebase. The application now uses TELEGRAM_BOT_TOKEN_ALERT and TELEGRAM_BOT_TOKEN_TRADING instead.

This was causing startup failures with error:
  Miss_key_exception: Key 'TELEGRAM_TOKEN' is missing

Changes:
- Removed TELEGRAM_TOKEN from Env_config dataclass
- Removed TELEGRAM_TOKEN from parse_env_config() function
- Updated test_env_loader.py to remove TELEGRAM_TOKEN from test cases

Fixes startup crash when .env file doesn't contain TELEGRAM_TOKEN field.