### PR TITLE
Fix import error in main module

### DIFF
--- a/src/fetch_data/deribit/deribit_client.py
+++ b/src/fetch_data/deribit/deribit_client.py
@@ -10,7 +10,7 @@ import websockets
 from websockets.exceptions import WebSocketException
 
 from .deribit_api import DeribitAPI, DeribitUserCfg
-from utils.config_loader.load_env_config import load_env_config
+from ...utils.config_loader.load_env_config import load_env_config
 
 logger = logging.getLogger(__name__)
 

--- a/src/fetch_data/polymarket/polymarket_api.py
+++ b/src/fetch_data/polymarket/polymarket_api.py
@@ -8,7 +8,7 @@ import certifi
 import requests
 from requests.exceptions import RequestException, HTTPError
 
-from utils.config_loader.load_env_config import load_env_config
+from ...utils.config_loader.load_env_config import load_env_config
 
 BASE_URL = "https://gamma-api.polymarket.com"
 LIST_MARKET_URL = f"{BASE_URL}/markets"

--- a/tests/utils/config_loader/test_load_env_config.py
+++ b/tests/utils/config_loader/test_load_env_config.py
@@ -1,4 +1,4 @@
-from utils.config_loader.load_env_config import Env_config, load_env_config, parse_env_config
+from src.utils.config_loader.load_env_config import Env_config, load_env_config, parse_env_config
 
 def test_parse_env_config():
     env = {


### PR DESCRIPTION
- Fixed import in polymarket_api.py: use relative import (...utils.config_loader)
- Fixed import in deribit_client.py: use relative import (...utils.config_loader)
- Fixed import in test_load_env_config.py: use absolute import (src.utils.config_loader)

This resolves ModuleNotFoundError: No module named 'utils' that was preventing the application from starting.