### PR TITLE
Track investment position with negative returns

### DIFF
--- a/src/utils/save_data/save_position.py
+++ b/src/utils/save_data/save_position.py
@@ -271,7 +271,8 @@ def save_position(
 
         # EV 相关数据计算
         pm_shares=pm_entry_cost / entry_price_pm if entry_price_pm > 0 else 0,
-        pm_slippage_usd=pm_entry_cost * slippage_pct,
+        # slippage_pct is a percentage (e.g., 9.77 for 9.77%), so divide by 100
+        pm_slippage_usd=pm_entry_cost * slippage_pct / 100,
         slippage_pct=slippage_pct,
         # 策略2: long K1 (ask), short K2 (bid)
         # 策略1: short K1 (bid), long K2 (ask)


### PR DESCRIPTION
The slippage_pct from get_polymarket_slippage is calculated as a percentage value (e.g., 9.77 for 9.77%), but save_position.py was multiplying directly without dividing by 100, causing pm_slippage_usd to be ~100x larger than expected.

This caused real_view.pnl_usd to show extremely negative values (e.g., -1951 USD for a 200 USD position) because the incorrect pm_slippage_usd was being subtracted as a fee.

Changes:
- save_position.py: divide slippage_pct by 100 when calculating pm_slippage_usd
- pnl.py: add sanity check to cap pm fees at 20% of entry cost for legacy data