### PR TITLE
Standardize timestamp format and add strike price tracking

### DIFF
--- a/src/utils/save_data/save_raw_data.py
+++ b/src/utils/save_data/save_raw_data.py
@@ -17,6 +17,13 @@ class RawData:
     market_id: str                  # Market identifier (e.g., BTC_108000_NO)
     spot_usd: float                 # Spot price of BTC
 
+    # Strike prices and expiry
+    k1_strike: Optional[float]      # K1 strike price
+    k2_strike: Optional[float]      # K2 strike price
+    k_poly: Optional[float]         # K_poly (Polymarket strike price)
+    dr_k_poly_iv: Optional[float]   # IV at K_poly strike on Deribit
+    expiry_timestamp: Optional[float]  # Option expiry timestamp (Unix seconds)
+
     # Polymarket YES token orderbook (3 levels)
     pm_yes_bid1_price: Optional[float]
     pm_yes_bid1_shares: Optional[float]
@@ -173,6 +180,13 @@ def save_raw_data(
         utc=unix_timestamp,
         market_id=pm_ctx.market_id,
         spot_usd=db_ctx.spot,
+
+        # Strike prices and expiry
+        k1_strike=db_ctx.k1_strike,
+        k2_strike=db_ctx.k2_strike,
+        k_poly=db_ctx.K_poly,
+        dr_k_poly_iv=db_ctx.mark_iv,
+        expiry_timestamp=db_ctx.k1_expiration_timestamp,
 
         # Polymarket YES orderbook
         pm_yes_bid1_price=pm_ctx.yes_bid_price_1,


### PR DESCRIPTION
## Summary
This PR standardizes the timestamp format across the codebase to use Unix timestamps (seconds since epoch) for consistency with Deribit's raw.csv format, and adds comprehensive strike price and expiry tracking to the raw data output.

## Key Changes

**Binance Options Monitor (`binance_options_monitor.py`)**
- Changed `BinanceOptionsSnapshot.timestamp` field from `YYYYMMDD_HHMMSS` string format to `utc` as Unix timestamp (float)
- Added `strikes` field to store all strike prices as a comma-separated string for easier reference
- Updated timestamp generation to use `datetime.timestamp()` instead of string formatting
- Updated logging to reflect the new timestamp format

**Raw Data Saving (`save_raw_data.py`)**
- Added new fields to `RawData` dataclass to track strike prices and expiry information:
  - `k1_strike`: K1 strike price
  - `k2_strike`: K2 strike price
  - `k_poly`: Polymarket strike price
  - `dr_k_poly_iv`: IV at K_poly strike on Deribit
  - `expiry_timestamp`: Option expiry timestamp (Unix seconds)
- Updated `save_raw_data()` function to populate these new fields from the database context

## Implementation Details
- Unix timestamp format provides better interoperability with external systems and is more suitable for time-series data analysis
- Strike price fields are optional to maintain flexibility for different data sources
- All timestamps now use Unix seconds format consistently across Binance and Deribit data