### PR TITLE
fix: handle Query objects in _build_pnl_where_clause

### DIFF
--- a/src/api/pnl.py
+++ b/src/api/pnl.py
@@ -376,17 +376,18 @@ def _build_pnl_where_clause(
     conditions = []
     params = []
 
-    if status:
+    # Handle Query objects when called directly (not via FastAPI)
+    if status and isinstance(status, str):
         status_upper = status.strip().upper()
         if status_upper in ('OPEN', 'CLOSE'):
             conditions.append("UPPER(status) = ?")
             params.append(status_upper)
 
-    if start_time:
+    if start_time and isinstance(start_time, str):
         conditions.append("entry_timestamp >= ?")
         params.append(start_time)
 
-    if end_time:
+    if end_time and isinstance(end_time, str):
         conditions.append("entry_timestamp <= ?")
         params.append(end_time)
 


### PR DESCRIPTION
When get_pnl_summary() is called directly from pnl_monitor.py (not via FastAPI endpoint), the Query default values aren't resolved to None.

Added isinstance(param, str) checks to handle this case gracefully.